### PR TITLE
fixes #11: wrong filter for wfs:wfs-1.1.0-Transaction-tc7.1

### DIFF
--- a/src/main/scripts/ctl/wfs-transaction/Transaction/wfs-1.1.0-Transaction-tc7.1-2.body.xml
+++ b/src/main/scripts/ctl/wfs-transaction/Transaction/wfs-1.1.0-Transaction-tc7.1-2.body.xml
@@ -7,7 +7,7 @@
   xmlns:sf="http://cite.opengeospatial.org/gmlsf">
 	<wfs:Query typeName="sf:EntitéGénérique">
 <ogc:Filter>
-<ogc:GmlObjectId gml:id="encode-for-uri($fid)"/>
+<ogc:GmlObjectId gml:id="{$fid}"/>
 </ogc:Filter>
 </wfs:Query>
 </wfs:GetFeature>


### PR DESCRIPTION
replaces encode-for-uri($fid) with {$fid} for GmlObjectId filter
