### PR TITLE
replace https with http

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <dependencies>
           <dependency>
             <groupId>org.apache.maven.doxia</groupId>
-            <artifactId>doxia-module-xhtml</artifactId>
+            <artifactId>doxia-module-markdown</artifactId>
             <version>1.6</version>
           </dependency>
         </dependencies>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -26,7 +26,7 @@
 
   <body>
     <links>
-      <item name="Issues" href="https://github.com/opengeospatial/ets-wfs11/issues"/>
+      <item name="Issues" href="http://github.com/opengeospatial/ets-wfs11/issues"/>
     </links>
     <menu name="Documentation">
       <item href="index.html" name="Overview" />


### PR DESCRIPTION
Please avoid URL with SSL. The Apache Maven Site Plugin has some problems with URL with ```https```. The URL starting with ```https``` will be interpreted as an internal URL.