### PR TITLE
Removed second part of the test wfs-1.1.0-Basic-DescribeFeatureType-tc5

### DIFF
--- a/src/main/scripts/ctl/basic/DescribeFeature/DescribeFeatureType-GET.xml
+++ b/src/main/scripts/ctl/basic/DescribeFeature/DescribeFeatureType-GET.xml
@@ -305,9 +305,8 @@
   <ctl:test name="wfs:wfs-1.1.0-Basic-DescribeFeatureType-tc5">
     <ctl:param name="CAPABILITIES"/>
     <ctl:assertion>The response for an invalid DescribeFeatureType request is an exception.</ctl:assertion>
-    <ctl:comment>DescribeFeatureType with [1] missing service parameter, [2] missing version parameter. Pass if all of
-      the following conditions are true: (1) the response is schema valid; (2) the root document is an ows:ExceptionReport
-      document.</ctl:comment>
+    <ctl:comment>DescribeFeatureType with missing service parameter. Pass if all of the following conditions are true:
+      (1) the response is schema valid; (2) the root document is an ows:ExceptionReport document.</ctl:comment>
     <link title="wfs:wfs-1.1.0-Basic-DescribeFeatureType-tc5">http://cite.opengeospatial.org/te2/about/wfs/1.1.0/site/ats-wfs11-basic-cc/DescribeFeatureType/GET/BasicDescribeFeatureType-GET-tc5.html</link>
     <ctl:link>OGC 04-094, 8.4, p.27</ctl:link>
     <ctl:code>
@@ -328,30 +327,8 @@
         </ctl:request>
       </xsl:variable>
 
-      <xsl:variable name="RESPONSE_MISSING_VERSION">
-        <ctl:request>
-          <ctl:url>
-            <xsl:value-of
-                    select="$CAPABILITIES/ows:OperationsMetadata/ows:Operation[@name='DescribeFeatureType']/ows:DCP/ows:HTTP/ows:Get/@xlink:href"/>
-          </ctl:url>
-          <ctl:method>get</ctl:method>
-          <ctl:param name="request">DescribeFeatureType</ctl:param>
-          <ctl:param name="service">WFS</ctl:param>
-          <parsers:HTTPParser>
-            <parsers:parse>
-              <parsers:HTTPParser/>
-            </parsers:parse>
-          </parsers:HTTPParser>
-        </ctl:request>
-      </xsl:variable>
-
       <xsl:if test="not($RESPONSE_MISSING_SERVICE//ows:Exception/*)">
         <ctl:message>FAILURE: DescribeFeatureType with missing service parameter does not throw an exception.
-        </ctl:message>
-        <ctl:fail/>
-      </xsl:if>
-      <xsl:if test="not($RESPONSE_MISSING_VERSION//ows:Exception/*)">
-        <ctl:message>FAILURE: DescribeFeatureType with missing version parameter does not throw an exception.
         </ctl:message>
         <ctl:fail/>
       </xsl:if>

--- a/src/site/markdown/ats-wfs11-basic-cc/DescribeFeatureType/GET/BasicDescribeFeatureType-GET-tc5.md
+++ b/src/site/markdown/ats-wfs11-basic-cc/DescribeFeatureType/GET/BasicDescribeFeatureType-GET-tc5.md
@@ -7,13 +7,12 @@
 Execute the following Test Steps:
 
 * Send the following DescribeFeatureType request by GET: wfs.DescribeFeatureType.get.url?VERSION=1.1.0&REQUEST=DescribeFeatureType
-* Send the following DescribeFeatureType request by GET: wfs.DescribeFeatureType.get.url?SERVICE=WFS&REQUEST=DescribeFeatureType
 
 
 **Conditions**
 
-* Response for DescribeFeatureType complies to xml schema: http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd for each request
-* Response for DescribeFeatureType contains [ows:Exception](#ows:Exception) for each request
+* Response complies to xml schema: http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd
+* Response contains [ows:Exception](#ows:Exception)
 
 **Reference(s)**: OGC 04-094, 8.4, p.27
 


### PR DESCRIPTION
Second part of **wfs-1.1.0-Basic-DescribeFeatureType-tc5** is removed as a missing version parameter does not always lead to an ows:Exception 1.1.

Fixes #66.
