### PR TITLE
Fixed request urls if URLs are not build by teamengine

### DIFF
--- a/src/main/java/org/opengis/cite/wfs11/WFSClient.java
+++ b/src/main/java/org/opengis/cite/wfs11/WFSClient.java
@@ -108,7 +108,7 @@ public class WFSClient {
 
 	private String buildGetFeatureGetRequest(QName typeName, String getUrl) {
 		StringBuilder sb = new StringBuilder();
-		sb.append(getUrl);
+		sb.append( fixGetUrl( getUrl ) );
 		sb.append("service=WFS&version=1.1.0&request=GetFeature&");
 		sb.append("typename=");
 		String namespaceURI = typeName.getNamespaceURI();
@@ -171,7 +171,7 @@ public class WFSClient {
 
 	private String buildGetFeatureTypeGetRequest(String getUrl) {
 		StringBuilder sb = new StringBuilder();
-		sb.append(getUrl);
+		sb.append(fixGetUrl( getUrl ));
 		sb.append("service=WFS&version=1.1.0&request=DescribeFeatureType");
 		return sb.toString();
 	}
@@ -192,5 +192,15 @@ public class WFSClient {
 		writer.close();
 		return connection.getInputStream();
 	}
+
+    private String fixGetUrl( String getUrl ) {
+        if ( getUrl != null ) {
+            if ( getUrl.indexOf( "?" ) == -1 )
+                return getUrl + "?";
+            if ( !getUrl.endsWith( "?" ) && !getUrl.endsWith( "&" ) )
+                return getUrl + "&";
+        }
+        return getUrl;
+    }
 
 }

--- a/src/main/scripts/ctl/basic/GetCapabilities/GetCapabilities-GET.xml
+++ b/src/main/scripts/ctl/basic/GetCapabilities/GetCapabilities-GET.xml
@@ -643,7 +643,7 @@
         <request>
           <url>
             <xsl:value-of
-                    select="concat($wfs.GetCapabilities.get.url,'version=1.1.0#request=GetCapabilities,service=WFS')"/>
+                    select="concat(wfs:fix-request-url($wfs.GetCapabilities.get.url),'version=1.1.0#request=GetCapabilities,service=WFS')"/>
           </url>
           <method>get</method>
           <p:XMLValidatingParser.GMLSF1/>

--- a/src/main/scripts/ctl/basic/GetFeature/GetFeature-GET.xml
+++ b/src/main/scripts/ctl/basic/GetFeature/GetFeature-GET.xml
@@ -589,7 +589,6 @@
       <xsl:variable name="result">
         <xsl:copy-of select="gfExt:findFeatureTypeAndPropertyName($wfs.GetCapabilities.document)" />
       </xsl:variable>
-
       <xsl:choose>
         <xsl:when test="$result != ''">
           <xsl:variable name="ftNamespace">
@@ -607,7 +606,6 @@
           <xsl:variable name="value">
             <xsl:value-of select="encode-for-uri($result/FeatureData/value)" />
           </xsl:variable>
-
           <xsl:variable name="request">
             <request>
               <url>
@@ -655,7 +653,7 @@
                     <parsers:schema type="resource">xsd/ogc/wfs/1.1.0/wfs.xsd</parsers:schema>
                     <parsers:schema type="url">
                       <xsl:value-of
-                        select="concat($wfs.DescribeFeatureType.get.url, 'service=WFS&amp;request=DescribeFeatureType&amp;version=1.1.0')" />
+                              select="concat(wfs:fix-request-url($wfs.DescribeFeatureType.get.url), 'service=WFS&amp;request=DescribeFeatureType&amp;version=1.1.0')" />
                     </parsers:schema>
                   </parsers:schemas>
                 </ctl:with-param>

--- a/src/main/scripts/ctl/functions.ctl
+++ b/src/main/scripts/ctl/functions.ctl
@@ -105,4 +105,28 @@
       <ctl:java class="java.lang.Thread" method="sleep"/>
    </ctl:function>
 
+  <ctl:function name="wfs:fix-request-url">
+    <ctl:param name="request-url">The request url to fix</ctl:param>
+    <ctl:return>The fixed request url.</ctl:return>
+    <ctl:description>Appends a '?' or '&amp;' at the end of the request url if missing.</ctl:description>
+    <ctl:code>
+      <xsl:choose>
+        <!-- append question mark if url does not contain a question mark -->
+        <xsl:when test="not(contains( $wfs.GetCapabilities.get.url, '?'))">
+          <xsl:value-of
+                  select="concat($wfs.GetCapabilities.get.url,'?', $request2QueryParams)" />
+        </xsl:when>
+        <!-- append ampersand if url contains a question mark but does not end with question mark or ampersand -->
+        <xsl:when
+                test="contains( $wfs.GetCapabilities.get.url, '?') and not(ends-with($wfs.GetCapabilities.get.url, '?') or ends-with($wfs.GetCapabilities.get.url, '&amp;')) ">
+          <xsl:value-of
+                  select="concat($wfs.GetCapabilities.get.url,'&amp;', $request2QueryParams)" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($wfs.GetCapabilities.get.url,$request2QueryParams)" />
+        </xsl:otherwise>
+      </xsl:choose>
+    </ctl:code>
+  </ctl:function>
+
 </ctl:package>


### PR DESCRIPTION
Fixes #73 and Fixed #78 

WFSClient was fixed to append '?' or '&' if missing in the end. Furthermore a new function was added to do this in CTL scripts. 

Replaces #79.

Can be tested with the folllowing SoapUI project containing a Mock Service (suffix .txt must be removed: [citesupport-soapui-project.xml.txt](https://github.com/opengeospatial/ets-wfs11/files/1706714/citesupport-soapui-project.xml.txt) and http://localhost:8080/services/wfs
