### PR TITLE
remove validating parser for bad version (VeERSION) test - wfs-1.1.0-…Basic-GetFeature-tc4

### DIFF
--- a/src/main/scripts/ctl/basic/GetFeature/GetFeature-GET.xml
+++ b/src/main/scripts/ctl/basic/GetFeature/GetFeature-GET.xml
@@ -469,7 +469,6 @@
                 select="concat('xmlns(', substring-before( $wfs.FeatureType.names.first, ':' ), '=', $wfs.FeatureType.names.first.namespace, ')')" />
             </xsl:if>
           </param>
-          <p:XMLValidatingParser.OWS />
         </request>
       </xsl:variable>
 


### PR DESCRIPTION
This is a follow up to PR https://github.com/opengeospatial/ets-wfs11/pull/97 (issue https://github.com/opengeospatial/ets-wfs11/issues/96).

I tested the last PR, and I ran is several times and it was working. However, I've switched to v1.34 and I've had some issues with it.
I expect this is my fault - I assume I made a boo-boo somewhere.


The issue is that the `<p:XMLValidatingParser.OWS />` gets a WFS 2.0 exception and isn't able to validated it.

I've removed this validation .

The main validation takes place a few lines later (line 543):
`          <xsl:if test="not($request3//*[local-name()='ExceptionReport'])">`

Sorry about this mistake!
